### PR TITLE
feat: configurable prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   "homepage": "https://github.com/interledgerjs/ilp-plugin-ethereum#readme",
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^2.11.1",
-    "eslint-config-standard": "^5.3.1",
-    "eslint-plugin-promise": "^1.3.1",
-    "eslint-plugin-standard": "^1.3.2",
+    "eslint": "^4.8.0",
+    "eslint-config-standard": "^10.2.1",
+    "eslint-plugin-promise": "^3.5.0",
+    "eslint-plugin-standard": "^3.0.1",
     "istanbul": "^0.4.3",
     "mocha": "^2.5.3",
     "mock-require": "^1.3.0"

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -30,7 +30,7 @@ class PluginEthereum extends EventEmitter2 {
 
     // information about ethereum contract
     this.contractAddress = opts.contract
-    this._prefix = 'g.crypto.ethereum.'
+    this._prefix = opts.prefix || 'g.crypto.ethereum.'
     this.web3 = null // local web3 instance
   }
 
@@ -62,7 +62,7 @@ class PluginEthereum extends EventEmitter2 {
 
   getInfo () {
     return {
-      prefix: 'g.crypto.ethereum.',
+      prefix: this._prefix,
       currencyCode: 'ETH',
       currencyScale: 9,
       connectors: []

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -11,7 +11,6 @@ const Ethereum = require('../model/ethereum')
 const uuid4 = require('node-uuid')
 
 class PluginEthereum extends EventEmitter2 {
-
   constructor (opts) {
     super()
 
@@ -116,7 +115,7 @@ class PluginEthereum extends EventEmitter2 {
     // TODO: merge Update and Fulfill
     debug('registering Update event handler')
     Ethereum.onEvent(this.contract, 'Update', async function (result) {
-      const { uuid, fulfillment } = result.args
+      const { uuid } = result.args
 
       const transfer = (await Ethereum.getTransfer(that.contract, uuid))
         .map((e) => e.toString())
@@ -202,7 +201,7 @@ class PluginEthereum extends EventEmitter2 {
     // TODO: better number conversion
     debug('getting the balance')
     const [ , balance ] = this.web3.eth.getBalance(this.address)
-      .match(/^(.+)\d{9}/) || [ , '0' ]
+      .match(/^(.+)\d{9}/) || [ undefined, '0' ]
 
     return balance
   }

--- a/src/model/ethereum.js
+++ b/src/model/ethereum.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const Web3 = require('web3')
 const debug = require('debug')('ilp-plugin-ethereum:ethereum')
 const abi = require('../abi/ledger.json')
 const stateToName = (state) => {
@@ -20,7 +19,7 @@ const accountToHex = (account, ledgerPrefix) => {
   return match[0]
 }
 const hexToAccount = (prefix, account) => prefix + '0x' + account.substring(2).toUpperCase()
-const uuidToHex = (uuid) => '0x' + uuid.replace(/\-/g, '')
+const uuidToHex = (uuid) => '0x' + uuid.replace(/-/g, '')
 const conditionToHex = (condition) => '0x' + Buffer.from(condition, 'base64').toString('hex')
 const fulfillmentToHex = conditionToHex
 const isoToHex = (web3, iso) => web3.toHex(Math.round((new Date(iso)).getTime() / 1000))
@@ -36,7 +35,7 @@ function waitForReceipt (web3, hash) {
         debug('poll error:', e.message)
       }
     }
-    
+
     poll()
   })
 }
@@ -48,10 +47,11 @@ function fulfillCondition (contract, { address, uuid, fulfillment }) {
       fulfillmentToHex(fulfillment), // fulfillment
       { from: address,
         // TODO: how much gas is correct?
-        gas: 300000 }, (error, result) => {
-          if (error) reject(error)
-          resolve(result)
-        })
+        gas: 300000 },
+      (error, result) => {
+        if (error) reject(error)
+        resolve(result)
+      })
   })
 }
 
@@ -66,10 +66,11 @@ function sendTransfer (contract, transfer, web3) {
       { from: accountToHex(transfer.from),
         value: gweiToWei(transfer.amount),
         // TODO: how much gas is correct?
-        gas: 1000000 }, (error, result) => {
-          if (error) reject(error)
-          resolve(result)
-        })
+        gas: 1000000 },
+      (error, result) => {
+        if (error) reject(error)
+        resolve(result)
+      })
   })
 }
 

--- a/src/model/ethereum.js
+++ b/src/model/ethereum.js
@@ -3,14 +3,22 @@
 const Web3 = require('web3')
 const debug = require('debug')('ilp-plugin-ethereum:ethereum')
 const abi = require('../abi/ledger.json')
-const accountRegex = /^g.crypto.ethereum.(.+?)(\.|$)/
 const stateToName = (state) => {
   return ([ 'prepare', 'fulfill', 'cancel', 'reject' ])[state]
 }
 
 // TODO: better number conversion
 const gweiToWei = (amount) => (amount + '000000000')
-const accountToHex = (account) => account.match(accountRegex)[1]
+const accountToHex = (account, ledgerPrefix) => {
+  if (!account.startsWith(ledgerPrefix)) {
+    throw new Error('account does not start with ledger prefix')
+  }
+  const match = account.substring(ledgerPrefix.length).match(/^(0x[0-9A-F]{40})$/g)
+  if (match === null) {
+    throw new Error('account is not a 40-digit upper case hex number')
+  }
+  return match[0]
+}
 const hexToAccount = (prefix, account) => prefix + '0x' + account.substring(2).toUpperCase()
 const uuidToHex = (uuid) => '0x' + uuid.replace(/\-/g, '')
 const conditionToHex = (condition) => '0x' + Buffer.from(condition, 'base64').toString('hex')

--- a/src/model/ethereum.js
+++ b/src/model/ethereum.js
@@ -13,7 +13,7 @@ const accountToHex = (account, ledgerPrefix) => {
   if (!account.startsWith(ledgerPrefix)) {
     throw new Error('account does not start with ledger prefix')
   }
-  const match = account.substring(ledgerPrefix.length).match(/^(0x[0-9A-F]{40})$/g)
+  const match = account.substring(ledgerPrefix.length).match(/^(0x[0-9A-F]{40})(\.|$)/g)
   if (match === null) {
     throw new Error('account is not a 40-digit upper case hex number')
   }


### PR DESCRIPTION
Basically same thing as https://github.com/ripple/ilp-plugin-xrp-escrow/pull/9

Not sure if there is a better way to do `accountToHex`, would it make sense if we created an `ilp-address` library that can parse an ILP address for the ledger part, the account part, etc?